### PR TITLE
Fixed arm-x86 problems with the power of rounding

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -17,6 +17,9 @@ func ExampleInverseKinematics() {
 	coordinates := kinematics.XyzWxyz{X: -100, Y: 250, Z: 250, Qx: 0.4007833787652043, Qy: -0.021233218878182854, Qz: 0.9086418268616911, Qw: 0.41903052745255764}
 	angles, _ := kinematics.InverseKinematics(coordinates, kinematics.AR3DhParameters)
 
-	fmt.Println(angles)
-	// Output: {1.8462740950010432 0.3416721655970939 -2.313720459511564 -1.7765008677785283 2.2218097507147707 1.2318789996199948}
+	// Math works slightly differently on arm and x86 machines when calculating
+	// inverse kinematics. We check 5 decimals deep, since it appears numbers can
+	// have slight variations between arm and x86 at 6 decimals.
+	fmt.Printf("%5f, %5f, %5f, %5f, %5f, %5f\n", angles.J1, angles.J2, angles.J3, angles.J4, angles.J5, angles.J6)
+	// Output: 1.846274, 0.341672, -2.313720, -1.776501, 2.221810, 1.231879
 }


### PR DESCRIPTION
Here I fixed the tests running on arm machines by rounding inverse kinematic calculations to 5 decimal places in our example tests.